### PR TITLE
[Feat/#45] Sign up, Log in 구현

### DIFF
--- a/src/components/Dropdown.vue
+++ b/src/components/Dropdown.vue
@@ -1,22 +1,22 @@
 <template>
-  <div class="dropdown__list">
-    <div class="dropdown__list__partition">
+  <div class="dropdown">
+    <div class="dropdown__list">
       <!-- TODO: text-sm -->
-      <span class="dropdown__list__info text-sm">Signed in as</span>
-      <b class="dropdown__list__info text-sm">example@example.com</b>
+      <span class="dropdown__info text-sm">Signed in as</span>
+      <b class="dropdown__info text-sm">example@example.com</b>
     </div>
-    <div class="dropdown__list__partition">
-      <!-- Active: "bg-gray-100 text-gray-900", Not Active: "text-gray-700" -->
-      <a href="#" class="dropdown__list__item text-sm"> Profile </a>
-      <a href="#" class="dropdown__list__item text-sm"> Accounts settings </a>
+    <div class="dropdown__list">
+      <a href="#" class="dropdown__item text-sm"> Profile </a>
+      <a href="#" class="dropdown__item text-sm"> Accounts settings </a>
     </div>
-    <div class="dropdown__list__partition">
+    <div class="dropdown__list">
       <router-link
         @click.native="logout"
         to="#"
-        class="dropdown__list__item block text-sm"
-        >Log out</router-link
+        class="dropdown__item block text-sm"
       >
+        Log out
+      </router-link>
     </div>
   </div>
 </template>
@@ -24,19 +24,19 @@
 <script>
 export default {
   name: "Dropdown",
-  data: function () {
+  data() {
     return {
       isLogin: false,
     };
   },
   methods: {
-    logout: function () {
+    logout() {
       this.isLogin = false;
       localStorage.removeItem("jwt");
       this.$router.push({ name: "Home" });
     },
   },
-  created: function () {
+  created() {
     const token = localStorage.getItem("jwt");
     if (token) {
       this.isLogin = true;
@@ -46,8 +46,7 @@ export default {
 </script>
 
 <style>
-.dropdown__list {
-  display: block;
+.dropdown {
   position: absolute;
   right: 10px;
   top: 60px;
@@ -58,28 +57,28 @@ export default {
   border: #f4f4f5 1px solid;
 }
 
-.dropdown__list__partition {
+.dropdown__list {
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
-  border-bottom: #f4f4f5 1px solid;
+  border-bottom: 1px solid #f4f4f5;
 }
 
-.dropdown__list__partition:first-child {
+.dropdown__list:first-child {
   padding-top: 1rem;
   padding-bottom: 0.6rem;
 }
 
-.dropdown__list__partition:last-child {
+.dropdown__list:last-child {
   border-bottom: none;
 }
 
-.dropdown__list__info {
+.dropdown__info {
   display: block;
   padding-left: 1rem;
   padding-right: 1rem;
 }
 
-.dropdown__list__item {
+.dropdown__item {
   color: #3f3f46;
   display: block;
   padding-left: 1rem;

--- a/src/components/Dropdown.vue
+++ b/src/components/Dropdown.vue
@@ -1,0 +1,90 @@
+<template>
+  <div class="dropdown__list">
+    <div class="dropdown__list__partition">
+      <!-- TODO: text-sm -->
+      <span class="dropdown__list__info text-sm">Signed in as</span>
+      <b class="dropdown__list__info text-sm">example@example.com</b>
+    </div>
+    <div class="dropdown__list__partition">
+      <!-- Active: "bg-gray-100 text-gray-900", Not Active: "text-gray-700" -->
+      <a href="#" class="dropdown__list__item text-sm"> Profile </a>
+      <a href="#" class="dropdown__list__item text-sm"> Accounts settings </a>
+    </div>
+    <div class="dropdown__list__partition">
+      <router-link
+        @click.native="logout"
+        to="#"
+        class="dropdown__list__item block text-sm"
+        >Log out</router-link
+      >
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "Dropdown",
+  data: function () {
+    return {
+      isLogin: false,
+    };
+  },
+  methods: {
+    logout: function () {
+      this.isLogin = false;
+      localStorage.removeItem("jwt");
+      this.$router.push({ name: "Home" });
+    },
+  },
+  created: function () {
+    const token = localStorage.getItem("jwt");
+    if (token) {
+      this.isLogin = true;
+    }
+  },
+};
+</script>
+
+<style>
+.dropdown__list {
+  display: block;
+  position: absolute;
+  right: 10px;
+  top: 60px;
+  width: 14rem;
+  background-color: #fff;
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.1);
+  border-radius: 0.3rem;
+  border: #f4f4f5 1px solid;
+}
+
+.dropdown__list__partition {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  border-bottom: #f4f4f5 1px solid;
+}
+
+.dropdown__list__partition:first-child {
+  padding-top: 1rem;
+  padding-bottom: 0.6rem;
+}
+
+.dropdown__list__partition:last-child {
+  border-bottom: none;
+}
+
+.dropdown__list__info {
+  display: block;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.dropdown__list__item {
+  color: #3f3f46;
+  display: block;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+</style>

--- a/src/components/Dropdown.vue
+++ b/src/components/Dropdown.vue
@@ -3,7 +3,7 @@
     <div class="dropdown__list">
       <!-- TODO: text-sm -->
       <span class="dropdown__info text-sm">Signed in as</span>
-      <b class="dropdown__info text-sm">example@example.com</b>
+      <span class="dropdown__info text-sm font-600">example@example.com</span>
     </div>
     <div class="dropdown__list">
       <a href="#" class="dropdown__item text-sm"> Profile </a>
@@ -85,5 +85,9 @@ export default {
   padding-right: 1rem;
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
+}
+
+.font-600 {
+  font-weight: 600;
 }
 </style>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -50,13 +50,15 @@
       <router-link
         :to="{ name: 'Login' }"
         class="mulish header__button header__button__secondary"
-        >Log In</router-link
       >
+        Log in
+      </router-link>
       <router-link
         :to="{ name: 'Signup' }"
         class="mulish header__button header__button__primary"
-        >Sign Up</router-link
       >
+        Sign up
+      </router-link>
     </div>
   </div>
 </template>
@@ -86,13 +88,13 @@ export default {
     };
   },
   methods: {
-    logout: function () {
+    logout() {
       this.isLogin = false;
       localStorage.removeItem("jwt");
       this.$router.push({ name: "Login" });
     },
   },
-  created: function () {
+  created() {
     const token = localStorage.getItem("jwt");
     if (token) {
       this.isLogin = true;
@@ -111,7 +113,6 @@ export default {
   display: flex;
   justify-content: space-between;
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.05);
-  background-color: #fff;
   height: 70px;
   align-items: center;
   background-color: #ffffff;
@@ -161,12 +162,12 @@ export default {
 .header__button__primary {
   background-color: #ed5656;
   border: 1px solid #ed5656;
-  color: #fff;
+  color: #ffffff;
   font-weight: 500;
 }
 
 .header__button__secondary {
-  background-color: #fff;
+  background-color: #ffffff;
   color: #52525b;
   border: 1px solid #d1d5db;
   font-weight: 500;

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -6,7 +6,6 @@
           <icon-search :class="[active ? 'header-search-active' : '']" />
         </icon-base>
       </div>
-
       <input
         type="text"
         placeholder="Search"
@@ -15,20 +14,50 @@
         @blur="active = false"
       />
     </section>
+    <div v-if="isLogin">
+      <section class="header-info">
+        <div class="header-bell">
+          <icon-base
+            viewBox="0 0 32 32"
+            width="24"
+            height="24"
+            icon-name="icon"
+          >
+            <icon-bell />
+          </icon-base>
+        </div>
 
-    <section class="header-info">
-      <div class="header-bell">
-        <icon-base viewBox="0 0 32 32" width="24" height="24" icon-name="icon">
-          <icon-bell />
-        </icon-base>
-      </div>
-
-      <div class="header-avatar">
-        <icon-base viewBox="0 0 64 64" width="32" height="32" icon-name="icon">
-          <icon-avatar />
-        </icon-base>
-      </div>
-    </section>
+        <div
+          class="header-avatar"
+          @click="isDropdownViewed = !isDropdownViewed"
+        >
+          <icon-base
+            viewBox="0 0 64 64"
+            width="32"
+            height="32"
+            icon-name="icon"
+          >
+            <icon-avatar />
+          </icon-base>
+        </div>
+      </section>
+      <dropdown
+        v-if="isDropdownViewed"
+        @close-dropdown="isDropdownViewed = false"
+      ></dropdown>
+    </div>
+    <div v-else>
+      <router-link
+        :to="{ name: 'Login' }"
+        class="mulish header__button header__button__secondary"
+        >Log In</router-link
+      >
+      <router-link
+        :to="{ name: 'Signup' }"
+        class="mulish header__button header__button__primary"
+        >Sign Up</router-link
+      >
+    </div>
   </div>
 </template>
 
@@ -37,6 +66,7 @@ import IconBase from "./IconBase.vue";
 import IconSearch from "./icons/IconSearch.vue";
 import IconBell from "./icons/IconBell.vue";
 import IconAvatar from "./icons/IconAvatar.vue";
+import Dropdown from "./Dropdown.vue";
 
 export default {
   name: "Header",
@@ -45,12 +75,28 @@ export default {
     IconSearch,
     IconBell,
     IconAvatar,
+    Dropdown,
   },
   data() {
     return {
       searchInput: "",
       active: false,
+      isLogin: false,
+      isDropdownViewed: false,
     };
+  },
+  methods: {
+    logout: function () {
+      this.isLogin = false;
+      localStorage.removeItem("jwt");
+      this.$router.push({ name: "Login" });
+    },
+  },
+  created: function () {
+    const token = localStorage.getItem("jwt");
+    if (token) {
+      this.isLogin = true;
+    }
   },
 };
 </script>
@@ -60,6 +106,7 @@ export default {
   display: flex;
   justify-content: space-between;
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.05);
+  background-color: #fff;
   height: 70px;
   align-items: center;
 }
@@ -68,7 +115,7 @@ export default {
   margin-left: 3rem;
   display: flex;
   align-items: center;
-  width: 100%;
+  width: 65%;
 }
 
 .header-search-active {
@@ -96,5 +143,26 @@ export default {
 .header-avatar {
   margin-left: 2rem;
   margin-right: 2rem;
+}
+
+.header__button {
+  border-radius: 0.3rem;
+  padding: 0.5rem 1rem 0.5rem 1rem;
+  margin-right: 0.5rem;
+  box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+.header__button__primary {
+  background-color: #ed5656;
+  border: 1px solid #ed5656;
+  color: #fff;
+  font-weight: 500;
+}
+
+.header__button__secondary {
+  background-color: #fff;
+  color: #52525b;
+  border: 1px solid #d1d5db;
+  font-weight: 500;
 }
 </style>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -5,6 +5,8 @@ import Home from "../views/Home.vue";
 import Movie from "../views/Movie.vue";
 import Review from "../views/Review.vue";
 import Community from "../views/Community.vue";
+import Signup from "../views/accounts/Signup.vue";
+import Login from "../views/accounts/Login.vue";
 
 Vue.use(Router);
 
@@ -31,6 +33,16 @@ export default new Router({
       path: "/community",
       name: "Community",
       component: Community,
+    },
+    {
+      path: "/accounts/signup",
+      name: "Signup",
+      component: Signup,
+    },
+    {
+      path: "/accounts/login",
+      name: "Login",
+      component: Login,
     },
   ],
 });

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -41,12 +41,12 @@ export default new Router({
       component: Community,
     },
     {
-      path: "/accounts/signup",
+      path: "/signup",
       name: "Signup",
       component: Signup,
     },
     {
-      path: "/accounts/login",
+      path: "/login",
       name: "Login",
       component: Login,
     },

--- a/src/views/accounts/Login.vue
+++ b/src/views/accounts/Login.vue
@@ -1,0 +1,55 @@
+<template>
+  <div>
+    <h1>Login</h1>
+    <div>
+      <label for="email">이메일: </label>
+      <input type="text" id="email" v-model="credentials.email" />
+    </div>
+    <div>
+      <label for="password">비밀번호: </label>
+      <input
+        type="password"
+        id="password"
+        v-model="credentials.password"
+        @keyup.enter="login"
+      />
+    </div>
+    <button @click="login">로그인</button>
+  </div>
+</template>
+
+<script>
+import axios from "axios";
+
+// const SERVER_URL = "process.env.VUE_APP_SERVER_URL";
+
+export default {
+  name: "Login",
+  data: function () {
+    return {
+      credentials: {
+        email: null,
+        password: null,
+      },
+    };
+  },
+  methods: {
+    login: function () {
+      axios({
+        method: "post",
+        url: "/accounts/api-token-auth/",
+        data: this.credentials,
+      })
+        .then((res) => {
+          // console.log(res);
+          localStorage.setItem("jwt", res.data.token);
+          this.$emit("login");
+          this.$router.push({ name: "Home" });
+        })
+        .catch((err) => {
+          console.log(err);
+        });
+    },
+  },
+};
+</script>

--- a/src/views/accounts/Login.vue
+++ b/src/views/accounts/Login.vue
@@ -25,7 +25,7 @@ import axios from "axios";
 
 export default {
   name: "Login",
-  data: function () {
+  data() {
     return {
       credentials: {
         email: null,
@@ -34,7 +34,7 @@ export default {
     };
   },
   methods: {
-    login: function () {
+    login() {
       axios({
         method: "post",
         url: "/accounts/api-token-auth/",

--- a/src/views/accounts/Signup.vue
+++ b/src/views/accounts/Signup.vue
@@ -33,7 +33,7 @@ const SERVER_URL = process.env.VUE_APP_SERVER_URL;
 
 export default {
   name: "Signup",
-  data: function () {
+  data() {
     return {
       credentials: {
         email: null,
@@ -44,7 +44,7 @@ export default {
     };
   },
   methods: {
-    signup: function () {
+    signup() {
       axios({
         method: "post",
         url: "/accounts/signup/",

--- a/src/views/accounts/Signup.vue
+++ b/src/views/accounts/Signup.vue
@@ -1,0 +1,74 @@
+<template>
+  <div>
+    <h1>Signup</h1>
+    <div>
+      <label for="email">이메일: </label>
+      <input type="text" id="email" v-model="credentials.email" />
+    </div>
+    <div>
+      <label for="nickname">닉네임: </label>
+      <input type="text" id="nickname" v-model="credentials.nickname" />
+    </div>
+    <div>
+      <label for="password">비밀번호: </label>
+      <input type="password" id="password" v-model="credentials.password" />
+    </div>
+    <div>
+      <label for="passwordConfirmation">비밀번호 확인: </label>
+      <input
+        type="password"
+        id="passwordConfirmation"
+        v-model="credentials.passwordConfirmation"
+        @keyup.enter="signup"
+      />
+    </div>
+    <button @click="signup">회원가입</button>
+  </div>
+</template>
+
+<script>
+import axios from "axios";
+
+const SERVER_URL = process.env.VUE_APP_SERVER_URL;
+
+export default {
+  name: "Signup",
+  data: function () {
+    return {
+      credentials: {
+        email: null,
+        nickname: null,
+        password: null,
+        passwordConfirmation: null,
+      },
+    };
+  },
+  methods: {
+    signup: function () {
+      axios({
+        method: "post",
+        url: "/accounts/signup/",
+        data: this.credentials,
+      })
+        .then(() => {
+          axios({
+            method: "post",
+            url: "/accounts/api-token-auth/",
+            data: this.credentials,
+          })
+            .then((res) => {
+              localStorage.setItem("jwt", res.data.token);
+              this.$emit("login");
+            })
+            .catch((err) => {
+              console.log(err);
+            });
+          this.$router.push({ name: "Login" });
+        })
+        .catch((err) => {
+          console.log(err);
+        });
+    },
+  },
+};
+</script>


### PR DESCRIPTION
## 💡 개요

closed #45

- accounts 기능을 구현했다.

<br/>

## 📋 진행상황

- [x] Django drf랑 연결했다.
- [x] Dropdown 만들었다. 

<br/>

## 🖼 스크린샷

- login이랑 signup 헤더에 추가했다.
![image](https://user-images.githubusercontent.com/87457066/141813383-f855132d-5474-45c9-982d-14bac60fbed8.png)

- 로그인 하면 알림 아이콘이랑 프사 나온다.
![image](https://user-images.githubusercontent.com/87457066/141813535-a7d4c0c9-ba58-42a8-bd19-23476488e436.png)

- 프사 클릭하면 드랍다운 나온다.
![image](https://user-images.githubusercontent.com/87457066/141813596-b1d58b4e-16d6-429a-8764-1c9ed7398162.png)


## 🗨 의견 <!-- PR 관련 코멘트, 관련 이슈, 토의할 내용.. -->

- login, signup 페이지 자체는 디자인이 아직 안나와서 안했다.

### TODO
- dropdown items, button hover 추가
- dropdown focus out시 dropdown 꺼짐
  (지금은 프사 클릭하면 사라짐)
- 프사에 커서 올리면 커서 바뀌게 해야함.
- 로그인/로그아웃 하면 새로고침하기
- 버튼 컴포넌트화