### PR TITLE
[Design/#72] 로그인, 회원가입 페이지 간단한 디자인

### DIFF
--- a/src/views/accounts/Login.vue
+++ b/src/views/accounts/Login.vue
@@ -93,6 +93,7 @@ export default {
   display: flex;
   flex-direction: column;
   align-items: center;
+  margin-top: 2rem;
 }
 
 .login__text {
@@ -127,6 +128,7 @@ export default {
   width: 100%;
   height: 2.5rem;
   padding: 0.5rem;
+  outline: none;
 }
 
 .login__button {

--- a/src/views/accounts/Login.vue
+++ b/src/views/accounts/Login.vue
@@ -1,28 +1,60 @@
 <template>
-  <div>
-    <h1>Login</h1>
-    <form @submit.prevent="login">
-      <div>
-        <label for="email">email: </label>
-        <input type="text" id="email" v-model="email" />
+  <div class="fixed">
+    <div class="container">
+      <div class="logo">
+        <router-link to="/">
+          <icon-base viewBox="0 0 43 54" width="6rem" height="6rem">
+            <icon-logo />
+          </icon-base>
+        </router-link>
       </div>
-      <div>
-        <label for="password">비밀번호: </label>
-        <input
-          type="password"
-          id="password"
-          v-model="password"
-          @keyup.enter="login"
-        />
+
+      <h1 class="login__text mulish">Log in to Foxie</h1>
+
+      <div class="card">
+        <form @submit.prevent="login">
+          <div>
+            <p class="login__label mulish">E-mail</p>
+            <input class="login__input" type="text" v-model="email" />
+          </div>
+
+          <div>
+            <p class="login__label mulish">Password</p>
+            <input
+              class="login__input"
+              type="password"
+              v-model="password"
+              @keyup.enter="login"
+            />
+          </div>
+
+          <router-link to="/">
+            <div class="login__button mulish" @click="login">Log in</div>
+          </router-link>
+        </form>
       </div>
-      <button @click="login">로그인</button>
-    </form>
+
+      <div class="login__footer">
+        <p>
+          아이디가 없으신가요?
+          <span class="sign__up mulish">
+            <router-link to="/signup"> Sign up </router-link></span
+          >
+        </p>
+      </div>
+    </div>
   </div>
 </template>
 
 <script>
+import IconBase from "@/components/IconBase.vue";
+import IconLogo from "@/components/icons/IconLogo.vue";
+
 export default {
-  name: "Login",
+  components: {
+    IconBase,
+    IconLogo,
+  },
   data() {
     return {
       email: "",
@@ -46,3 +78,71 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+.fixed {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: 101;
+  background-color: var(--background);
+}
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.login__text {
+  color: var(--text);
+  font-size: 28px;
+  font-weight: 200;
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+}
+
+.card {
+  width: 20rem;
+  background-color: var(--header);
+  box-shadow: 0px 1px 2px 1px rgba(0, 0, 0, 0.06);
+  padding: 2rem 1rem;
+  border-radius: 8px;
+  margin-bottom: 2rem;
+}
+
+.login__label {
+  margin-bottom: 0.2rem;
+  font-weight: 200;
+  padding-left: 0.3rem;
+  font-size: 14px;
+}
+
+.login__input {
+  background-color: var(--background);
+  border: 1px solid var(--board-header);
+  margin-bottom: 1.5rem;
+  border-radius: 4px;
+  width: 100%;
+  height: 2.5rem;
+  padding: 0.5rem;
+}
+
+.login__button {
+  width: 100%;
+  background-color: var(--coral);
+  border-radius: 8px;
+  text-align: center;
+  margin-top: 1.5rem;
+  padding: 0.5rem;
+  color: var(--white);
+  font-weight: 700;
+}
+
+.sign__up {
+  margin-left: 0.5rem;
+  color: var(--coral);
+  font-weight: 600;
+}
+</style>

--- a/src/views/accounts/Signup.vue
+++ b/src/views/accounts/Signup.vue
@@ -1,36 +1,62 @@
 <template>
-  <div>
-    <h1>Signup</h1>
-    <form @submit.prevent="signup">
-      <div>
-        <label for="email">이메일: </label>
-        <input type="text" id="email" v-model="email" />
+  <div class="fixed">
+    <div class="container">
+      <div class="logo">
+        <router-link to="/">
+          <icon-base viewBox="0 0 43 54" width="6rem" height="6rem">
+            <icon-logo />
+          </icon-base>
+        </router-link>
       </div>
-      <div>
-        <label for="username">username: </label>
-        <input type="text" id="username" v-model="username" />
+
+      <h1 class="signup__text mulish">Welcome to Foxie</h1>
+
+      <div class="card">
+        <form @submit.prevent="signup">
+          <div>
+            <p class="signup__label mulish">E-mail</p>
+            <input class="signup__input" type="text" v-model="email" />
+          </div>
+
+          <div>
+            <p class="signup__label mulish">User name</p>
+            <input class="signup__input" type="text" v-model="username" />
+          </div>
+
+          <div>
+            <p class="signup__label mulish">Password</p>
+            <input class="signup__input" type="password" v-model="password1" />
+          </div>
+
+          <div>
+            <p class="signup__label mulish">Password confirm</p>
+            <input
+              class="signup__input"
+              type="password"
+              v-model="password2"
+              @keyup.enter="signup"
+            />
+          </div>
+
+          <router-link to="/">
+            <div class="signup__button mulish" @click="signup">Sign up</div>
+          </router-link>
+        </form>
       </div>
-      <div>
-        <label for="password1">비밀번호: </label>
-        <input type="password" id="password1" v-model="password1" />
-      </div>
-      <div>
-        <label for="password2">비밀번호 확인: </label>
-        <input
-          type="password"
-          id="password2"
-          v-model="password2"
-          @keyup.enter="signup"
-        />
-      </div>
-      <button @click="signup">회원가입</button>
-    </form>
+    </div>
   </div>
 </template>
 
 <script>
+import IconBase from "@/components/IconBase.vue";
+import IconLogo from "@/components/icons/IconLogo.vue";
+
 export default {
-  name: "Signup",
+  components: {
+    IconBase,
+    IconLogo,
+  },
+
   data() {
     return {
       email: "",
@@ -58,3 +84,73 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+.fixed {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: 101;
+  background-color: var(--background);
+}
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 2rem;
+}
+
+.signup__text {
+  color: var(--text);
+  font-size: 28px;
+  font-weight: 200;
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+}
+
+.card {
+  width: 20rem;
+  background-color: var(--header);
+  box-shadow: 0px 1px 2px 1px rgba(0, 0, 0, 0.06);
+  padding: 2rem 1rem;
+  border-radius: 8px;
+  margin-bottom: 2rem;
+}
+
+.signup__label {
+  margin-bottom: 0.2rem;
+  font-weight: 200;
+  padding-left: 0.3rem;
+  font-size: 14px;
+}
+
+.signup__input {
+  background-color: var(--background);
+  border: 1px solid var(--board-header);
+  margin-bottom: 1.5rem;
+  border-radius: 4px;
+  width: 100%;
+  height: 2.5rem;
+  padding: 0.5rem;
+  outline: none;
+}
+
+.signup__button {
+  width: 100%;
+  background-color: var(--coral);
+  border-radius: 8px;
+  text-align: center;
+  margin-top: 1.5rem;
+  padding: 0.5rem;
+  color: var(--white);
+  font-weight: 700;
+}
+
+.sign__in {
+  margin-left: 0.5rem;
+  color: var(--coral);
+  font-weight: 600;
+}
+</style>


### PR DESCRIPTION
## 💡 개요

closed #72

- 로그인 회원가입 페이지 간단하게 디자인 했따. 바꿀거다.

<br/>

## 📋 진행상황

- [x] 로그인 페이지 임시 디자인
- [x] 회원가입 페이지 임시 디자인

<br/>

## 🖼 스크린샷
![image](https://user-images.githubusercontent.com/43740455/142729702-949e1525-532d-4038-8273-a52b5531d660.png)

![image](https://user-images.githubusercontent.com/43740455/142729652-5874f704-13dd-4c70-a9bc-5cc9b392c917.png)

## 🗨 의견 <!-- PR 관련 코멘트, 관련 이슈, 토의할 내용.. -->

- 다른 급한 일 처리하고 돌아올 목적으로 임시 디자인 했당
- `is_login` 으로 헤더 사이드바 숨기는 건 고난도라서 나중에 할 생각..